### PR TITLE
Bruk kun nyeste arbeidssøkerperiode fra asr

### DIFF
--- a/.github/workflows/deploy-toi-arbeidssoekeropplysninger.yaml
+++ b/.github/workflows/deploy-toi-arbeidssoekeropplysninger.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/feature/asr
+      deploy_dev_branch: refs/heads/korriger_skralt_asr
     secrets: inherit
     permissions:
       contents: read

--- a/apps/toi-arbeidssoekeropplysninger/nais-prod.yaml
+++ b/apps/toi-arbeidssoekeropplysninger/nais-prod.yaml
@@ -2,4 +2,4 @@ kafka_pool: nav-prod
 cloudsql_tier: db-custom-2-7680
 kafka_consumer_group_id: toi-arbeidssoekeropplysninger-rapidconsumer-1
 arbeidssoker_opplysninger_kafka_group_id: toi-arbeidssoekeropplysninger-2
-publiser_til_rapid_enabled: enabled
+publiser_til_rapid_enabled: disabled

--- a/apps/toi-arbeidssoekeropplysninger/src/main/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekeropplysninger/Application.kt
+++ b/apps/toi-arbeidssoekeropplysninger/src/main/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekeropplysninger/Application.kt
@@ -29,7 +29,7 @@ fun main() {
     RapidApplication.create(System.getenv()).apply {
         val consumer = { KafkaConsumer<Long, OpplysningerOmArbeidssoeker>(consumerConfig) }
 
-        ArbeidssoekeropplysningerBehovLytter(this, repository)
+        //ArbeidssoekeropplysningerBehovLytter(this, repository) // Vi kan slutte å lytte på disse opplysningene
         ArbeidssoekerperiodeRapidLytter(this, repository)
         val arbeidssoekeropplysningerLytter = ArbeidssoekeropplysningerLytter(consumer, repository)
         register(arbeidssoekeropplysningerLytter)

--- a/apps/toi-arbeidssoekeropplysninger/src/main/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekeropplysninger/ArbeidssoekerperiodeRapidLytter.kt
+++ b/apps/toi-arbeidssoekeropplysninger/src/main/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekeropplysninger/ArbeidssoekerperiodeRapidLytter.kt
@@ -47,7 +47,7 @@ class ArbeidssoekerperiodeRapidLytter(private val rapidsConnection: RapidsConnec
     ) {
         log.info("Mottok arbeidssøkerperiodemelding ${packet["@id"]}")
         repository.lagreOppfølgingsperiodemelding(packet.fjernMetadataOgKonverter());
-        secure(log).info("Mottok og lagret arbeidssøkerperiodemelding med id ${packet["@id"]} for fnr ${packet["fodselsnummer"]}")
+        //secure(log).info("Mottok og lagret arbeidssøkerperiodemelding med id ${packet["@id"]} for fnr ${packet["fodselsnummer"]}")
     }
 
     private fun JsonMessage.fjernMetadataOgKonverter(): JsonNode {

--- a/apps/toi-arbeidssoekeropplysninger/src/main/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekeropplysninger/Repository.kt
+++ b/apps/toi-arbeidssoekeropplysninger/src/main/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekeropplysninger/Repository.kt
@@ -286,9 +286,9 @@ data class PeriodeOpplysninger(
                 ?.atZone(ZoneId.of("Europe/Oslo")),
             behandletDato = rs.getTimestamp("behandlet_dato")?.toInstant()?.atZone(ZoneId.of("Europe/Oslo")),
             helsetilstandHindrerArbeid = rs.getBoolean("helsetilstand_hindrer_arbeid")
-                .let { if (rs.wasNull()) null else it },
+                .let { if (rs.wasNull()) false else it },
             andreForholdHindrerArbeid = rs.getBoolean("andre_forhold_hindrer_arbeid")
-                .let { if (rs.wasNull()) null else it }
+                .let { if (rs.wasNull()) false else it }
         )
     }
 }

--- a/apps/toi-arbeidssoekeropplysninger/src/main/resources/db/migration/V1_4__add_current_view.sql
+++ b/apps/toi-arbeidssoekeropplysninger/src/main/resources/db/migration/V1_4__add_current_view.sql
@@ -1,0 +1,13 @@
+create or replace view nyeste_asr_periode as
+select p1.id, p1.aktor_id, p1.periode_startet, p1.periode_avsluttet, p1.behandlet_dato
+    from periodemelding p1
+    where not exists (select 1
+        from periodemelding p2
+        where
+            p1.aktor_id = p2.aktor_id
+            and p2.periode_startet is not null
+            and p2.periode_startet > p1.periode_startet
+        )
+        and p1.periode_startet is not null
+;
+

--- a/apps/toi-arbeidssoekerperiode/nais-prod.yaml
+++ b/apps/toi-arbeidssoekerperiode/nais-prod.yaml
@@ -1,3 +1,3 @@
 kafka_pool: nav-prod
 kafka_consumer_group_id: toi-arbeidssoekerperiode-rapidconsumer-1
-arbeidssoker_periode_kafka_group_id: toi-arbeidssoekerperiode-3
+arbeidssoker_periode_kafka_group_id: toi-arbeidssoekerperiode-4


### PR DESCRIPTION
Lager et view som inneholde kun nyeste arbeidssøkerperiode for aktørId
Bruker dette viewet til å kun publisere meldinger for den nyeste perioden, samt kun bruke nyeste perioden i svar på need spørringer.

Hvis vi bestemmer oss for ikke å bruke andre_forhold_hindrer_arbeid og helse_hindrer_arbeid (som vi bør gjøre) så bør de neste stegene være noe a la:

1. Fjern andre_forhold_hindrer_arbeid og helse_hindrer_arbeid  fra toi-synlighetsmotor (database + kode)
2. Slutt og lytte på arbeidssøkeropplysninger
3. Fjern de feltene fra Periodeopplysninger, og spør direkte mot view'er – ikke bruke where id in ..

**Oppdatert**: Vi lager fortsatt viewet, men bruker det ikke. Det kan brukes til manuell kvalitetssikring og slettes i en ryddepr i ettertid. Nå baserer vi oss på å sikre at vi ikke overskriver nye periode med gamle. Har disablet lesing av arbeidssøkeropplysninger, samt redusert logging til securelog.