### PR TITLE
Fjern arbeidssokeropplysninger

### DIFF
--- a/.github/workflows/deploy-toi-synlighetsmotor.yaml
+++ b/.github/workflows/deploy-toi-synlighetsmotor.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/feature/asr
+      deploy_dev_branch: refs/heads/fjern_arbeidssokeropplysninger
     secrets: inherit
     permissions:
       contents: read

--- a/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Evaluering.kt
+++ b/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Evaluering.kt
@@ -40,8 +40,6 @@ class Evaluering(
     val erIkkeKvp: BooleanVerdi,
     val harIkkeAdressebeskyttelse: BooleanVerdi,
     val erArbeidssøker: BooleanVerdi,
-    val erIkkeAndreForholdHindrerArbeid: BooleanVerdi,
-    val erIkkeHelseHindrerArbeid: BooleanVerdi,
     komplettBeregningsgrunnlag: Boolean
 ) {
     private val felterBortsettFraAdressebeskyttelse = listOf(
@@ -56,14 +54,12 @@ class Evaluering(
         erIkkeSperretAnsatt,
         erIkkeDoed,
         erIkkeKvp,
-        //erArbeidssøker, // Disse feltene skal foreløpig ikke være en del av evalueringen, fjern fra harAltBortsettFraAdressebeskyttelse når de implementeres
-        //erIkkeAndreForholdHindrerArbeid,
-        //erIkkeHelseHindrerArbeid
+        //erArbeidssøker // Disse feltene skal foreløpig ikke være en del av evalueringen, fjern fra harAltBortsettFraAdressebeskyttelse når de implementeres
     )
 
     private val minstEtFeltErUsynlig = felterBortsettFraAdressebeskyttelse.any { it == False }
     val harAltBortsettFraAdressebeskyttelse =
-        (felterBortsettFraAdressebeskyttelse + erArbeidssøker + erIkkeAndreForholdHindrerArbeid + erIkkeHelseHindrerArbeid)
+        (felterBortsettFraAdressebeskyttelse + erArbeidssøker)
             .none { it == Missing }
     private val ukomplettMenGirUsynlig = harAltBortsettFraAdressebeskyttelse && minstEtFeltErUsynlig
     val erFerdigBeregnet = komplettBeregningsgrunnlag || ukomplettMenGirUsynlig
@@ -81,9 +77,7 @@ class Evaluering(
         harRiktigFormidlingsgruppe = harRiktigFormidlingsgruppe.default(false),
         erIkkeSperretAnsatt = erIkkeSperretAnsatt.default(false),
         erIkkeDoed = erIkkeDoed.default(false),
-        erArbeidssøker = erArbeidssøker.default(false),
-        erIkkeAndreForholdHindrerArbeid = erIkkeAndreForholdHindrerArbeid.default(false),
-        erIkkeHelseHindrerArbeid = erIkkeHelseHindrerArbeid.default(false)
+        erArbeidssøker = erArbeidssøker.default(false)
     )
 
 
@@ -123,9 +117,7 @@ data class EvalueringUtenDiskresjonskode(
     val harRiktigFormidlingsgruppe: Boolean,
     val erIkkeSperretAnsatt: Boolean,
     val erIkkeDoed: Boolean,
-    val erArbeidssøker: Boolean,
-    val erIkkeAndreForholdHindrerArbeid: Boolean,
-    val erIkkeHelseHindrerArbeid: Boolean
+    val erArbeidssøker: Boolean
     ) {
     companion object {
         fun medAlleVerdierFalse() = EvalueringUtenDiskresjonskode(
@@ -138,9 +130,7 @@ data class EvalueringUtenDiskresjonskode(
             harRiktigFormidlingsgruppe = false,
             erIkkeSperretAnsatt = false,
             erIkkeDoed = false,
-            erArbeidssøker = false,
-            erIkkeAndreForholdHindrerArbeid = false,
-            erIkkeHelseHindrerArbeid = false
+            erArbeidssøker = false
         )
     }
 }

--- a/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Kandidat.kt
+++ b/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Kandidat.kt
@@ -43,14 +43,10 @@ data class Kandidat(
         erIkkeKvp = !erKvp,
         harIkkeAdressebeskyttelse = adressebeskyttelse.hvisIkkeNullOg(::harIkkeAdressebeskyttelse),
         erArbeidssøker = arbeidssøkeropplysninger.hvisIkkeNullOg(::erArbeidssøker),
-        erIkkeAndreForholdHindrerArbeid = arbeidssøkeropplysninger.hvisIkkeNullOg(::erIkkeAndreForholdHindrerArbeid),
-        erIkkeHelseHindrerArbeid = arbeidssøkeropplysninger.hvisIkkeNullOg(::erIkkeHelseHindrerArbeid),
         komplettBeregningsgrunnlag = beregningsgrunnlag()
     )
 
     private fun erArbeidssøker(it: Arbeidssøkeropplysninger) = it.erArbeidssøker()
-    private fun erIkkeAndreForholdHindrerArbeid(it: Arbeidssøkeropplysninger) = it.andreForholdHindrerArbeid?.let { ! it } ?: true
-    private fun erIkkeHelseHindrerArbeid(it: Arbeidssøkeropplysninger) = it.helseHindrerArbeid?.let { ! it } ?: true
     private fun maaIkkeBehandleTidligereCv(it: MåBehandleTidligereCv) = !it.maaBehandleTidligereCv
     private fun erIkkeArenaFritattKandidatsøk(it: ArenaFritattKandidatsøk) = !it.erFritattKandidatsøk
     private fun harRiktigFormidlingsgruppe(it: Oppfølgingsinformasjon) = it.formidlingsgruppe == Formidlingsgruppe.ARBS
@@ -172,11 +168,7 @@ data class Arbeidssøkeropplysninger(
     @JsonProperty("periode_startet")
     val periodeStartet: ZonedDateTime? = null,
     @JsonProperty("periode_avsluttet")
-    val periodeAvsluttet: ZonedDateTime? = null,
-    @JsonProperty("helsetilstand_hindrer_arbeid")
-    val helseHindrerArbeid: Boolean?,
-    @JsonProperty("andre_forhold_hindrer_arbeid")
-    val andreForholdHindrerArbeid: Boolean?
+    val periodeAvsluttet: ZonedDateTime? = null
 ) {
     fun erArbeidssøker() =
         periodeStartet != null && periodeAvsluttet == null

--- a/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Repository.kt
+++ b/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Repository.kt
@@ -23,8 +23,6 @@ class Repository(private val dataSource: DataSource) {
     private val erIkkeDødKolonne = "er_ikke_doed"
     private val erIkkeKvpKolonne = "er_ikke_kvp"
     private val erArbeidssøkerKolonne = "er_arbeidssoker"
-    private val erIkkeAndreForholdHindrerArbeidKolonne = "er_ikke_annet_hindrer_arb"
-    private val erIkkeHelseHindrerArbeidKolonne = "er_ikke_helse_hindrer_arb"
     private val erFerdigBeregnetKolonne = "er_ferdig_beregnet"
 
     fun lagre(evaluering: Evaluering, aktørId: String, fødselsnummer: String?) {
@@ -115,10 +113,7 @@ class Repository(private val dataSource: DataSource) {
         erIkkeKvp = resultset.getBoolean(erIkkeKvpKolonne).tilBooleanVerdi(), // TODO
         harIkkeAdressebeskyttelse = BooleanVerdi.missing, // TODO denne har vi ikke i databasen ennå
         erArbeidssøker = resultset.getBoolean(erArbeidssøkerKolonne).tilBooleanVerdi(),
-        erIkkeAndreForholdHindrerArbeid = resultset.getBoolean(erIkkeAndreForholdHindrerArbeidKolonne).tilBooleanVerdi(),
-        erIkkeHelseHindrerArbeid = resultset.getBoolean(erIkkeHelseHindrerArbeidKolonne).tilBooleanVerdi(),
         komplettBeregningsgrunnlag = resultset.getBoolean(erFerdigBeregnetKolonne)
-
     )
 
     private fun kolonneString(kolonner: List<String>) =
@@ -144,8 +139,6 @@ class Repository(private val dataSource: DataSource) {
             erIkkeDødKolonne to erIkkeDoed.default(true),     //TODO
             erIkkeKvpKolonne to erIkkeKvp.default(true),     //TODO
             erArbeidssøkerKolonne to erArbeidssøker.default(false), //???
-            erIkkeAndreForholdHindrerArbeidKolonne to erIkkeAndreForholdHindrerArbeid.default(true),
-            erIkkeHelseHindrerArbeidKolonne to erIkkeHelseHindrerArbeid.default(true),
             erFerdigBeregnetKolonne to erFerdigBeregnet
         )
     }

--- a/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/SynlighetsevalueringsgrunnlagLytterTest.kt
+++ b/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/SynlighetsevalueringsgrunnlagLytterTest.kt
@@ -33,7 +33,7 @@ class SynlighetsevalueringsgrunnlagLytterTest {
         HJEMMEL("hjemmel", hjemmel(), hjemmel(opprettetDato = null, slettetDato = null)),
         MÅBEHANDLETIDLIGERECV("måBehandleTidligereCv", måBehandleTidligereCv(false), måBehandleTidligereCv(true)),
         KVP("kvp", kvp(event = "AVSLUTTET"), kvp(event = "STARTET")),
-        ARBEIDSSOKEROPPLYSNINGER("arbeidssokeropplysninger", arbeidssøkeropplysninger(), arbeidssøkeropplysninger(true, true)),
+        ARBEIDSSOKEROPPLYSNINGER("arbeidssokeropplysninger", arbeidssøkeropplysninger(), arbeidssøkeropplysninger()),
     }
 
     private val adressebeskyttelseFeltNavn = "adressebeskyttelse"

--- a/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/SynlighetsmotorTest.kt
+++ b/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/SynlighetsmotorTest.kt
@@ -50,9 +50,6 @@ class SynlighetsmotorTest {
                 false.tilBooleanVerdi(),
                 false.tilBooleanVerdi(),
                 false.tilBooleanVerdi(),
-                false.tilBooleanVerdi(),
-                false.tilBooleanVerdi(),
-
                 false
             ), "123456789", null
         )
@@ -80,8 +77,6 @@ class SynlighetsmotorTest {
             assertThat(erIkkeDoed.default(false)).isEqualTo(true)
             assertThat(erIkkeKvp.default(false)).isEqualTo(true)
             assertThat(erArbeidssøker.default(false)).isEqualTo(true)
-            assertThat(erIkkeHelseHindrerArbeid.default(false)).isEqualTo(true)
-            assertThat(erIkkeAndreForholdHindrerArbeid.default(false)).isEqualTo(true)
             //assertThat(harIkkeAdressebeskyttelse).isEqualTo(true) TODO: denne har vi ikke i databasen ennå
             assertThat(erFerdigBeregnet).isEqualTo(true)
         } ?: Assertions.fail("Fant ikke evaluering i databasen")

--- a/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/Testdata.kt
+++ b/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/Testdata.kt
@@ -232,15 +232,13 @@ class Testdata {
             }
         """.trimIndent()
 
-        fun arbeidssøkeropplysninger(helseHindrerArbeid: Boolean = false, andreForholdHindrerArbeid: Boolean = false) =
+        fun arbeidssøkeropplysninger() =
             """
             "arbeidssokeropplysninger": {
                 "periode_id": "0b0e2261-343d-488e-a70f-807f4b151a2f",
                 "identitetsnummer": "01010012345",
                 "periode_startet": "2020-10-30T14:15:38+01:00",
-                "periode_avsluttet": null,
-                "helsetilstand_hindrer_arbeid": $helseHindrerArbeid,
-                "andre_forhold_hindrer_arbeid": $andreForholdHindrerArbeid
+                "periode_avsluttet": null
             }
         """.trimIndent()
 


### PR DESCRIPTION
Fjerner feltene helse_hindrer_arbeid og andre_forhold_hindrer arbeid fra synlighetsmotoren.
Kollonene i databasen fjernes i en egen pr etter at denne er deployet