### PR TITLE
Reduser størrelse på Securelogs fil

### DIFF
--- a/apps/toi-arbeidsgiver-notifikasjon/logback.xml
+++ b/apps/toi-arbeidsgiver-notifikasjon/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-arbeidsmarked-cv/logback.xml
+++ b/apps/toi-arbeidsmarked-cv/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-arbeidssoekeropplysninger/logback.xml
+++ b/apps/toi-arbeidssoekeropplysninger/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-arbeidssoekerperiode/logback.xml
+++ b/apps/toi-arbeidssoekerperiode/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-arena-fritatt-kandidatsok/src/main/resources/logback.xml
+++ b/apps/toi-arena-fritatt-kandidatsok/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-evaluertdatalogger/src/main/resources/logback.xml
+++ b/apps/toi-evaluertdatalogger/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-hjemmel/src/main/resources/logback.xml
+++ b/apps/toi-hjemmel/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-hull-i-cv/src/main/resources/logback.xml
+++ b/apps/toi-hull-i-cv/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-kandidatfeed/logback.xml
+++ b/apps/toi-kandidatfeed/logback.xml
@@ -15,7 +15,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-kvp/logback.xml
+++ b/apps/toi-kvp/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-livshendelse/logback.xml
+++ b/apps/toi-livshendelse/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-maa-behandle-tidligere-cv/logback.xml
+++ b/apps/toi-maa-behandle-tidligere-cv/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-ontologitjeneste/logback.xml
+++ b/apps/toi-ontologitjeneste/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-oppfolgingsinformasjon/logback.xml
+++ b/apps/toi-oppfolgingsinformasjon/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-oppfolgingsperiode/logback.xml
+++ b/apps/toi-oppfolgingsperiode/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-organisasjonsenhet/logback.xml
+++ b/apps/toi-organisasjonsenhet/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>

--- a/apps/toi-publisering-til-arbeidsplassen/logback.xml
+++ b/apps/toi-publisering-til-arbeidsplassen/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-sammenstille-kandidat/logback.xml
+++ b/apps/toi-sammenstille-kandidat/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-siste-14a-vedtak/logback.xml
+++ b/apps/toi-siste-14a-vedtak/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-stilling-indekser/logback.xml
+++ b/apps/toi-stilling-indekser/logback.xml
@@ -21,7 +21,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">

--- a/apps/toi-veileder/logback.xml
+++ b/apps/toi-veileder/logback.xml
@@ -12,7 +12,7 @@
             <maxIndex>1</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
+            <maxFileSize>64MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>


### PR DESCRIPTION
for å unngå at podden havner i en dårlig tilstand når vi overskrider masks størrelse (gitt av Nais?).

https://trello.com/c/UP3FyRvH