### PR TITLE
Skru av ARBS og skru på ASR

### DIFF
--- a/.github/workflows/deploy-toi-synlighetsmotor.yaml
+++ b/.github/workflows/deploy-toi-synlighetsmotor.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/fjern_databaseskrot
+      deploy_dev_branch: refs/heads/bruk_asr
     secrets: inherit
     permissions:
       contents: read

--- a/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Evaluering.kt
+++ b/apps/toi-synlighetsmotor/src/main/kotlin/no/nav/arbeidsgiver/toi/Evaluering.kt
@@ -49,17 +49,17 @@ class Evaluering(
         maaIkkeBehandleTidligereCv,
         arenaIkkeFritattKandidatsøk,
         erUnderOppfoelging,
-        harRiktigFormidlingsgruppe,
+        //harRiktigFormidlingsgruppe, // ARBS skal ikke lenger være en del av evalueringen. Kommentert ut frem til vi er sikre på at det kan slettes helt
         erIkkeKode6eller7,
         erIkkeSperretAnsatt,
         erIkkeDoed,
         erIkkeKvp,
-        //erArbeidssøker // Disse feltene skal foreløpig ikke være en del av evalueringen, fjern fra harAltBortsettFraAdressebeskyttelse når de implementeres
+        erArbeidssøker
     )
 
     private val minstEtFeltErUsynlig = felterBortsettFraAdressebeskyttelse.any { it == False }
     val harAltBortsettFraAdressebeskyttelse =
-        (felterBortsettFraAdressebeskyttelse + erArbeidssøker)
+        (felterBortsettFraAdressebeskyttelse + harRiktigFormidlingsgruppe)
             .none { it == Missing }
     private val ukomplettMenGirUsynlig = harAltBortsettFraAdressebeskyttelse && minstEtFeltErUsynlig
     val erFerdigBeregnet = komplettBeregningsgrunnlag || ukomplettMenGirUsynlig

--- a/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/SynlighetsmotorTest.kt
+++ b/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/SynlighetsmotorTest.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.toi
 
 import no.nav.arbeidsgiver.toi.Testdata.Companion.avsluttetOppfølgingsperiode
 import no.nav.arbeidsgiver.toi.Testdata.Companion.arbeidsmarkedCv
+import no.nav.arbeidsgiver.toi.Testdata.Companion.arbeidssøkeropplysninger
 import no.nav.arbeidsgiver.toi.Testdata.Companion.arenaFritattKandidatsøk
 import no.nav.arbeidsgiver.toi.Testdata.Companion.harCvManglerJobbprofil
 import no.nav.arbeidsgiver.toi.Testdata.Companion.harEndreJobbrofil
@@ -20,6 +21,7 @@ import no.nav.arbeidsgiver.toi.Testdata.Companion.participatingService
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 
@@ -184,19 +186,27 @@ class SynlighetsmotorTest {
 
 
 
+    @Test
+    fun `om Person ikke er aktiv i arbeidssøkerregisteret skal synlighet være false`() = testProgramMedHendelse(
+        komplettHendelseSomFørerTilSynlighetTrue(arbeidssøkeropplysninger = arbeidssøkeropplysninger(aktiv = false)),
+        enHendelseErPublisertMedSynlighetsverdiOgFerdigBeregnet(false, true)
+    )
 
+    @Disabled("Testen kan slettes når vi er klare for å slette bruk av ARBS")
     @Test
     fun `formidlingsgruppe ARBS skal også anses som gyldig formidlingsgruppe`() = testProgramMedHendelse(
         komplettHendelseSomFørerTilSynlighetTrue(oppfølgingsinformasjon = oppfølgingsinformasjon(formidlingsgruppe = "ARBS")),
         enHendelseErPublisertMedSynlighetsverdiOgFerdigBeregnet(true, true)
     )
 
+    @Disabled("Testen kan slettes når vi er klare for å slette bruk av ARBS")
     @Test
     fun `om Person har formidlingsgruppe IARBS skal synlighet være false`() = testProgramMedHendelse(
         komplettHendelseSomFørerTilSynlighetTrue(oppfølgingsinformasjon = oppfølgingsinformasjon(formidlingsgruppe = "IARBS")),
         enHendelseErPublisertMedSynlighetsverdiOgFerdigBeregnet(false, true)
     )
 
+    @Disabled("Testen kan slettes når vi er klare for å slette bruk av ARBS")
     @Test
     fun `om Person har feil formidlingsgruppe skal synlighet være false`() = testProgramMedHendelse(
         komplettHendelseSomFørerTilSynlighetTrue(oppfølgingsinformasjon = oppfølgingsinformasjon(formidlingsgruppe = "IKKEARBSELLERIARBS")),

--- a/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/Testdata.kt
+++ b/apps/toi-synlighetsmotor/src/test/kotlin/no/nav/arbeidsgiver/toi/Testdata.kt
@@ -232,15 +232,17 @@ class Testdata {
             }
         """.trimIndent()
 
-        fun arbeidssøkeropplysninger() =
-            """
-            "arbeidssokeropplysninger": {
-                "periode_id": "0b0e2261-343d-488e-a70f-807f4b151a2f",
-                "identitetsnummer": "01010012345",
-                "periode_startet": "2020-10-30T14:15:38+01:00",
-                "periode_avsluttet": null
-            }
-        """.trimIndent()
+        fun arbeidssøkeropplysninger(aktiv: Boolean = true) :String {
+            val avsluttet = if (aktiv) "null" else "\"2020-10-31T14:15:38+01:00\""
+            return """
+                "arbeidssokeropplysninger": {
+                    "periode_id": "0b0e2261-343d-488e-a70f-807f4b151a2f",
+                    "identitetsnummer": "01010012345",
+                    "periode_startet": "2020-10-30T14:15:38+01:00",
+                    "periode_avsluttet": $avsluttet
+                }
+            """.trimIndent()
+        }
 
         fun avsluttetOppfølgingsperiode() =
             """


### PR DESCRIPTION
Skrur på arbeidssøkerregisteret i evalueringen, og skrur av sjekk på ARBS.

De gamle testene med ARBS er disablet og ikke slettet. Venter med sletting til vi har kjør en liten stund med asr og er helt sikre på at vi kan fjerne arbs helt.